### PR TITLE
fix: handle gaps in TRAI column when reading by time range

### DIFF
--- a/src/vallenae/io/_sql.py
+++ b/src/vallenae/io/_sql.py
@@ -241,76 +241,79 @@ def sql_binary_search(
     lower_bound: bool = True,
 ) -> int | None:
     """
-    Helper function to find the boundary index for given condition on a sorted column.
+    Find a boundary index for a monotonic condition on a value column sorted by an index column.
 
-    Especially using conditions on the pridb's and tradb's Time column are expensive (not indexed).
-    E.g.: SELECT * FROM view_tr_data WHERE Time > 10 AND Time < 100
+    Conditions on the pridb's and tradb's Time column are expensive (Time is not indexed),
+    e.g.: SELECT * FROM view_tr_data WHERE Time > 10 AND Time < 100
 
-    Because the Time column is monotonic increasing, a fast binary search can be applied.
-    The Time column is not *stricly* monotonic increasing; different channels might share the same
-    timestamp. To find the lower/upper bound of same values, a subsequent linear search is applied.
+    Because Time increases monotonically with the indexed column (e.g. the tradb's TRAI), a fast
+    binary search over the index column can locate the boundary instead. The index column is
+    monotonic but *not* dense - it may contain gaps (missing values) - so each probe is snapped
+    to the nearest existing row in the search direction; a missing index is never queried.
 
     Args:
         connection: SQLite connection
         table: Table name
-        column_value: Name of the sorted column, e.g. Time
-        column_index: Name of the indexed column
-        fun_compare: Lambda function of the condition, e.g. `lambda t: t > 10` (Time > 10)
-        lower_bound: Specify which index to return for ranges of same values.
-            Default: Return lower bound (`True`)
+        column_value: Name of the sorted (monotonic) column, e.g. Time
+        column_index: Name of the indexed column, e.g. TRAI
+        fun_compare: Lambda function of the condition, e.g. `lambda t: t > 10` (Time > 10).
+            The condition must be monotonic in `column_value`, i.e. switch from `False` to `True`
+            (use `lower_bound=True`) or from `True` to `False` (use `lower_bound=False`) exactly
+            once over the sorted range.
+        lower_bound: Search direction. `True` snaps probes upwards and returns the boundary at the
+            lower end of the matching range (for `False`->`True` conditions). `False` snaps
+            downwards and returns the boundary at the upper end (for `True`->`False` conditions).
+            Default: `True`.
+
+    Returns:
+        A threshold for the `column_index` that separates matching from non-matching rows, or
+        `None` if the condition is `False` for every row.
+
+        The returned value is meant to be used as an inclusive range bound on `column_index`
+        (`column_index >= result` for `lower_bound=True`, `column_index <= result` for
+        `lower_bound=False`). Because the index column may be sparse, the threshold is **not
+        guaranteed to be an existing index** - it can be any value within the gap that separates
+        the matching from the non-matching rows. All such values select the same set of rows, so
+        this is exact for range filtering; do not interpret the result as a concrete row key.
     """
 
     # two querys are way faster than one combined!
-    i_min_total = connection.execute(f"SELECT MIN({column_index}) FROM {table}").fetchone()[0]
-    i_max_total = connection.execute(f"SELECT MAX({column_index}) FROM {table}").fetchone()[0]
+    i_min = connection.execute(f"SELECT MIN({column_index}) FROM {table}").fetchone()[0]
+    i_max = connection.execute(f"SELECT MAX({column_index}) FROM {table}").fetchone()[0]
+    if i_min is None:  # empty table
+        return None
+
+    # Snap each probe to the nearest existing row in the search direction (ASC/DESC), so a gap in
+    # the index column never results in a missing-row lookup. Each snap is an O(log n) index seek.
+    op, order = (">=", "ASC") if lower_bound else ("<=", "DESC")
 
     def get_value(index):
-        cur = connection.execute(
-            f"SELECT {column_value} FROM {table} WHERE {column_index} == ?", (index,)
-        )
-        return cur.fetchone()[0]
+        return connection.execute(
+            f"SELECT {column_value} FROM {table} "
+            f"WHERE {column_index} {op} ? ORDER BY {column_index} {order} LIMIT 1",
+            (index,),
+        ).fetchone()[0]
 
-    def binary_search():
-        i_min, i_max = i_min_total, i_max_total
-        while True:
-            v_min = get_value(i_min)
-            v_max = get_value(i_max)
-            if v_min > v_max:
-                raise ValueError(f"Value column {column_value} not sorted")
-            c_min = fun_compare(v_min)
-            c_max = fun_compare(v_max)
+    while True:
+        v_min = get_value(i_min)
+        v_max = get_value(i_max)
+        if v_min > v_max:
+            raise ValueError(f"Value column {column_value} not sorted")
+        c_min = fun_compare(v_min)
+        c_max = fun_compare(v_max)
 
-            if c_min and c_max:  # condition true for both limits
-                return i_min if lower_bound else i_max
-            if not c_min and not c_max:  # condition false for both limits
-                return None
+        if c_min and c_max:  # condition true for the whole range
+            return i_min if lower_bound else i_max
+        if not c_min and not c_max:  # condition false for the whole range
+            return None
+        if i_max - i_min < 2:  # adjacent bounds straddle the transition
+            return i_min if c_min else i_max
 
-            if i_max - i_min < 2:
-                return i_min if c_min is True else i_max
-
-            i_mid = (i_max + i_min) // 2
-            c_mid = fun_compare(get_value(i_mid))
-
-            if c_mid == c_min:
-                i_min = i_mid
-            else:
-                i_max = i_mid
-
-    def bound_same_value(start: int):
-        """Find lower/upper bound of same values with linear search."""
-        v_start = get_value(start)
-        inc = -1 if lower_bound else 1
-        i = start
-        while i_min_total < i < i_max_total:
-            i += inc
-            if get_value(i) != v_start:
-                return i - inc
-        return i
-
-    i = binary_search()
-    if i is not None:
-        return bound_same_value(i)
-    return i
+        i_mid = (i_min + i_max) // 2
+        if fun_compare(get_value(i_mid)) == c_min:
+            i_min = i_mid
+        else:
+            i_max = i_mid
 
 
 def create_new_database(filename: str, schema: str):

--- a/tests/test_io_sql.py
+++ b/tests/test_io_sql.py
@@ -186,50 +186,75 @@ def test_read_sql_generator_parameter(memory_abc):
 def test_sql_binary_search():
     con = sqlite3.connect(":memory:")
     con.execute("CREATE TABLE squares (id INTEGER PRIMARY KEY, value REAL)")
-    con.execute("CREATE TABLE consts (id INTEGER PRIMARY KEY, value INT)")
-    con.execute("CREATE TABLE step (id INTEGER PRIMARY KEY, value INT)")
+    con.execute("CREATE TABLE consts (id INTEGER PRIMARY KEY, value REAL)")
     con.execute("CREATE TABLE sin (id INTEGER PRIMARY KEY, value REAL)")
     for i in range(100):
         con.execute("INSERT INTO squares (id, value) VALUES (?, ?)", (i, i**2))
         con.execute("INSERT INTO consts (id, value) VALUES (?, ?)", (i, 11))
-        con.execute("INSERT INTO step (id, value) VALUES (?, ?)", (i, int(i >= 33)))
         con.execute("INSERT INTO sin (id, value) VALUES (?, ?)", (i, sin(i)))
 
-    # squares table
-    # condition false for all values
+    # The condition must be monotonic in `value`: lower_bound=True for False->True conditions
+    # (`>`/`>=`, match at high end, used downstream as `id >= result`), lower_bound=False for
+    # True->False conditions (`<`/`<=`, match at low end, used as `id <= result`).
+
+    # squares table: strictly increasing, distinct values -> result is the exact boundary id
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 9) == 3  # id 3 -> 9
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 9) == 4  # id 4 -> 16
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 256) == 16
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 9, lower_bound=False) == 2
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x <= 9, lower_bound=False) == 3
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 256, lower_bound=False) == 15
+
+    # condition false for the whole range -> None
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 0) is None
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 99**2) is None
+    # condition true for the whole range -> first / last id
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0) == 0
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0, lower_bound=False) == 99
 
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 9) == 4
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 9) == 3
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 9) == 2
-
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 256) == 17
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 256) == 16
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 256) == 15
-
-    # consts table
-    # condition false for all values
-    assert sql_binary_search(con, "consts", "value", "id", lambda x: x < 11) is None
-    assert sql_binary_search(con, "consts", "value", "id", lambda x: x > 11) is None
-    # condition true for all values
+    # consts table: all values equal -> whole range matches or none
     assert sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11) == 0
-    assert sql_binary_search(con, "consts", "value", "id", lambda x: x == 11) == 0
-    assert sql_binary_search(con, "consts", "value", "id", lambda x: x <= 11) == 0
-    # return upper bound if condition is true for both bounds
-    assert (
-        sql_binary_search(con, "consts", "value", "id", lambda x: x == 11, lower_bound=False) == 99
-    )
-
-    # step table
-    assert sql_binary_search(con, "step", "value", "id", lambda x: x == 0) == 0
-    assert sql_binary_search(con, "step", "value", "id", lambda x: x == 0, lower_bound=False) == 32
-    assert sql_binary_search(con, "step", "value", "id", lambda x: x >= 1) == 33
-    assert sql_binary_search(con, "step", "value", "id", lambda x: x >= 1, lower_bound=False) == 99
+    assert sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11, lower_bound=False) == 99
+    assert sql_binary_search(con, "consts", "value", "id", lambda x: x > 11) is None
+    assert sql_binary_search(con, "consts", "value", "id", lambda x: x < 11) is None
 
     # sin table, not sorted -> expect exception
     with pytest.raises(ValueError):
         sql_binary_search(con, "sin", "value", "id", lambda x: x >= 0.5)
+
+    con.close()
+
+
+def test_sql_binary_search_sparse_index():
+    """Regression: a sparse index column (like the tradb's TRAI) has gaps, so arithmetic midpoints
+    can hit missing rows - this used to raise `TypeError: 'NoneType' object is not subscriptable`.
+    The result is a threshold for range filtering, so it need not be an existing id: any value in
+    the gap between the last non-matching and the first matching row is correct."""
+    con = sqlite3.connect(":memory:")
+    con.execute("CREATE TABLE gapped (id INTEGER PRIMARY KEY, value REAL)")
+    for i in [1, 2, 3, 50, 51, 90, 91, 1000]:  # non-contiguous ids, value == id
+        con.execute("INSERT INTO gapped (id, value) VALUES (?, ?)", (i, float(i)))
+
+    # ids 3 and 50 straddle a gap: `value >= 50` matches from id 50, so any threshold in (3, 50]
+    # selects the right rows; `value < 50` ends at id 3, so any threshold in [3, 50) does.
+    upper = sql_binary_search(con, "gapped", "value", "id", lambda v: v >= 50)
+    lower = sql_binary_search(con, "gapped", "value", "id", lambda v: v < 50, lower_bound=False)
+    assert upper is not None
+    assert lower is not None
+    assert 3 < upper <= 50
+    assert 3 <= lower < 50
+    # across a different gap: `value >= 1000` matches only id 1000 -> threshold in (91, 1000]
+    far = sql_binary_search(con, "gapped", "value", "id", lambda v: v >= 1000)
+    assert far is not None
+    assert 91 < far <= 1000
+
+    # whole range matches / no match
+    assert sql_binary_search(con, "gapped", "value", "id", lambda v: v >= 0) == 1  # MIN(id)
+    assert sql_binary_search(con, "gapped", "value", "id", lambda v: v < 0) is None
+
+    # empty table
+    con.execute("CREATE TABLE empty (id INTEGER PRIMARY KEY, value REAL)")
+    assert sql_binary_search(con, "empty", "value", "id", lambda v: v >= 0) is None
 
     con.close()
 


### PR DESCRIPTION
`read_continuous_wave`/`iread` with a time range crashed with `TypeError: 'NoneType' object is not subscriptable` on tradb files whose TRAI column is sparse (has gaps). The binary search over TRAI probed arithmetic midpoints with `WHERE TRAI == <mid>`, which returns no row when that TRAI doesn't exist.

Snap each probe to the nearest existing row in the search direction instead, so a missing index is never queried. Since the result is only used as a range bound (`TRAI >= start` / `TRAI <= stop`), it no longer needs to be an existing index — any threshold in the gap selects the same rows. This also lets the same-value linear bounding be dropped.