### PR TITLE
fix: correct time-range to sample mapping in TraDatabase.read_continuous_wave

### DIFF
--- a/src/vallenae/io/_sql.py
+++ b/src/vallenae/io/_sql.py
@@ -266,15 +266,15 @@ def sql_binary_search(
             Default: `True`.
 
     Returns:
-        A threshold for the `column_index` that separates matching from non-matching rows, or
-        `None` if the condition is `False` for every row.
+        The existing `column_index` value at the boundary of the matching rows, or `None` if the
+        condition is `False` for every row.
 
-        The returned value is meant to be used as an inclusive range bound on `column_index`
-        (`column_index >= result` for `lower_bound=True`, `column_index <= result` for
-        `lower_bound=False`). Because the index column may be sparse, the threshold is **not
-        guaranteed to be an existing index** - it can be any value within the gap that separates
-        the matching from the non-matching rows. All such values select the same set of rows, so
-        this is exact for range filtering; do not interpret the result as a concrete row key.
+        When several rows share the boundary value (e.g. simultaneous records on different
+        channels sharing a timestamp), `lower_bound=True` returns the **first** of them and
+        `lower_bound=False` the **last**, so the result is safe as an inclusive bound on
+        `column_index` (`column_index >= result` / `column_index <= result`). The index column
+        may be sparse (contain gaps); the search never queries a missing index and always
+        returns an existing one.
     """
 
     # two querys are way faster than one combined!
@@ -283,37 +283,53 @@ def sql_binary_search(
     if i_min is None:  # empty table
         return None
 
-    # Snap each probe to the nearest existing row in the search direction (ASC/DESC), so a gap in
-    # the index column never results in a missing-row lookup. Each snap is an O(log n) index seek.
-    op, order = (">=", "ASC") if lower_bound else ("<=", "DESC")
-
-    def get_value(index):
+    def value_at(index):
         return connection.execute(
-            f"SELECT {column_value} FROM {table} "
-            f"WHERE {column_index} {op} ? ORDER BY {column_index} {order} LIMIT 1",
-            (index,),
+            f"SELECT {column_value} FROM {table} WHERE {column_index} == ?", (index,)
         ).fetchone()[0]
 
+    def neighbour(index, op, order):
+        """Nearest existing row in a direction, snapping over index gaps."""
+        return connection.execute(
+            f"SELECT {column_index}, {column_value} FROM {table} "
+            f"WHERE {column_index} {op} ? ORDER BY {column_index} {order} LIMIT 1",
+            (index,),
+        ).fetchone()
+
+    # i_low/i_high are existing indices; condition differs between them once narrowed
+    i_low, i_high = i_min, i_max
+    v_low, v_high = value_at(i_low), value_at(i_high)
+    if v_low > v_high:
+        raise ValueError(f"Value column {column_value} not sorted")
+    c_low, c_high = fun_compare(v_low), fun_compare(v_high)
+    if c_low == c_high:  # condition constant over the whole range
+        if not c_low:
+            return None  # never matches
+        return i_min if lower_bound else i_max  # always matches
+
+    # Binary search for two adjacent *existing* rows that straddle the transition. Each probe is
+    # snapped to an existing index near the midpoint, so a gap in the index column is never queried.
     while True:
-        v_min = get_value(i_min)
-        v_max = get_value(i_max)
-        if v_min > v_max:
-            raise ValueError(f"Value column {column_value} not sorted")
-        c_min = fun_compare(v_min)
-        c_max = fun_compare(v_max)
-
-        if c_min and c_max:  # condition true for the whole range
-            return i_min if lower_bound else i_max
-        if not c_min and not c_max:  # condition false for the whole range
-            return None
-        if i_max - i_min < 2:  # adjacent bounds straddle the transition
-            return i_min if c_min else i_max
-
-        i_mid = (i_min + i_max) // 2
-        if fun_compare(get_value(i_mid)) == c_min:
-            i_min = i_mid
+        i_mid = (i_low + i_high) // 2
+        row = neighbour(i_mid, "<=", "DESC")  # existing index in (i_low, i_mid]
+        if row is None or row[0] <= i_low:
+            row = neighbour(i_mid, ">", "ASC")  # else the next existing index above i_mid
+        if row is None or row[0] >= i_high:
+            break  # i_low and i_high are adjacent existing rows
+        if fun_compare(row[1]) == c_low:
+            i_low = row[0]
         else:
-            i_max = i_mid
+            i_high = row[0]
+
+    # Walk to the requested edge of the run of rows sharing the boundary (True-side) value.
+    boundary = i_low if c_low else i_high
+    value = value_at(boundary)
+    op, order = ("<", "DESC") if lower_bound else (">", "ASC")
+    while True:
+        row = neighbour(boundary, op, order)
+        if row is None or row[1] != value:
+            return boundary
+        boundary = row[0]
 
 
 def create_new_database(filename: str, schema: str):

--- a/src/vallenae/io/_sql.py
+++ b/src/vallenae/io/_sql.py
@@ -6,7 +6,7 @@ import logging
 import sqlite3
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Iterator, Sequence, TypeVar
+from typing import Any, Callable, Iterator, Literal, Sequence, TypeVar
 
 from ._types import SizedIterable
 
@@ -237,8 +237,7 @@ def sql_binary_search(
     column_value: str,
     column_index: str,
     fun_compare: Callable[[float], bool],
-    *,
-    lower_bound: bool = True,
+    bound: Literal["lower", "upper"] = "lower",
 ) -> int | None:
     """
     Find a boundary index for a monotonic condition on a value column sorted by an index column.
@@ -258,24 +257,26 @@ def sql_binary_search(
         column_index: Name of the indexed column, e.g. TRAI
         fun_compare: Lambda function of the condition, e.g. `lambda t: t > 10` (Time > 10).
             The condition must be monotonic in `column_value`, i.e. switch from `False` to `True`
-            (use `lower_bound=True`) or from `True` to `False` (use `lower_bound=False`) exactly
+            (use `bound="lower"`) or from `True` to `False` (use `bound="upper"`) exactly
             once over the sorted range.
-        lower_bound: Search direction. `True` snaps probes upwards and returns the boundary at the
-            lower end of the matching range (for `False`->`True` conditions). `False` snaps
+        bound: Search direction. `"lower"` snaps probes upwards and returns the boundary at the
+            lower end of the matching range (for `False`->`True` conditions). `"upper"` snaps
             downwards and returns the boundary at the upper end (for `True`->`False` conditions).
-            Default: `True`.
+            Default: `"lower"`.
 
     Returns:
         The existing `column_index` value at the boundary of the matching rows, or `None` if the
         condition is `False` for every row.
 
         When several rows share the boundary value (e.g. simultaneous records on different
-        channels sharing a timestamp), `lower_bound=True` returns the **first** of them and
-        `lower_bound=False` the **last**, so the result is safe as an inclusive bound on
+        channels sharing a timestamp), `bound="lower"` returns the **first** of them and
+        `bound="upper"` the **last**, so the result is safe as an inclusive bound on
         `column_index` (`column_index >= result` / `column_index <= result`). The index column
         may be sparse (contain gaps); the search never queries a missing index and always
         returns an existing one.
     """
+
+    is_lower = bound == "lower"
 
     # two querys are way faster than one combined!
     i_min = connection.execute(f"SELECT MIN({column_index}) FROM {table}").fetchone()[0]
@@ -305,7 +306,7 @@ def sql_binary_search(
     if c_low == c_high:  # condition constant over the whole range
         if not c_low:
             return None  # never matches
-        return i_min if lower_bound else i_max  # always matches
+        return i_min if is_lower else i_max  # always matches
 
     # Binary search for two adjacent *existing* rows that straddle the transition. Each probe is
     # snapped to an existing index near the midpoint, so a gap in the index column is never queried.
@@ -324,7 +325,7 @@ def sql_binary_search(
     # Walk to the requested edge of the run of rows sharing the boundary (True-side) value.
     boundary = i_low if c_low else i_high
     value = value_at(boundary)
-    op, order = ("<", "DESC") if lower_bound else (">", "ASC")
+    op, order = ("<", "DESC") if is_lower else (">", "ASC")
     while True:
         row = neighbour(boundary, op, order)
         if row is None or row[1] != value:

--- a/src/vallenae/io/tradb.py
+++ b/src/vallenae/io/tradb.py
@@ -94,25 +94,41 @@ class TraDatabase(Database):
 
     def _get_total_time_range(self) -> tuple[float, float]:
         """Return total time range [first sample time, end of last sample] in seconds."""
-        # view_tr_data.Time is already in seconds; the end of a record is
-        # Time + Samples / SampleRate (the `* 1.0` forces float division).
-        row = (
-            self.connection()
-            .execute("SELECT MIN(Time), MAX(Time + Samples * 1.0 / SampleRate) FROM view_tr_data")
-            .fetchone()
-        )
-        if row is None or row[0] is None:  # empty table
+        con = self.connection()
+        # Time is monotonic with TRAI, so the first/last sample come from the records with the
+        # min/max TRAI - indexed point lookups instead of a full-table scan over the data.
+        first = con.execute(
+            "SELECT Time FROM tr_data WHERE TRAI == (SELECT MIN(TRAI) FROM tr_data)"
+        ).fetchone()
+        if first is None or first[0] is None:  # empty table
             return 0.0, 0.0
-        return row[0], row[1]
+        last = con.execute(
+            "SELECT Time, Samples, SampleRate FROM tr_data "
+            "WHERE TRAI == (SELECT MAX(TRAI) FROM tr_data)"
+        ).fetchone()
+        return first[0] / self._timebase, last[0] / self._timebase + last[1] / last[2]
+
+    def _first_trai_at_same_time(self, trai: int) -> int:
+        """Return the smallest TRAI sharing the same Time as `trai` (simultaneous records)."""
+        # Stream existing rows backwards from `trai` (indexed primary-key scan) and stop as soon as
+        # Time changes. The run spans at most one record per channel, so only a few rows are read.
+        cursor = self.connection().execute(
+            "SELECT TRAI, Time FROM tr_data WHERE TRAI <= ? ORDER BY TRAI DESC", (trai,)
+        )
+        first, time = cursor.fetchone()  # the row for `trai` itself (highest TRAI <= trai)
+        for row_trai, row_time in cursor:
+            if row_time != time:
+                break
+            first = row_trai
+        return first
 
     def _get_trai_range_from_time_range(
         self, time_start: float | None, time_stop: float | None
     ) -> tuple[int | None, int | None]:
-        """Binary-search the TRAI range of records overlapping a time range.
+        """Binary-search the inclusive TRAI range of records overlapping a time range.
 
-        Records have a duration, so the range includes the record straddling
-        time_start (start <= time_start) and the record starting at time_stop.
-        view_tr_data.Time is in seconds, so the conditions compare seconds directly.
+        Records have a duration, so the bounds are the last record starting at/before each
+        endpoint. view_tr_data.Time is in seconds, so the conditions compare seconds directly.
         """
         search = partial(
             sql_binary_search,
@@ -121,13 +137,15 @@ class TraDatabase(Database):
             column_value="Time",
             column_index="TRAI",
         )
-        trai_start = None
-        trai_stop = None
-        if time_start is not None:  # last record starting at/before time_start
+        trai_start = trai_stop = None
+        if time_start is not None:
+            # last record starting at/before time_start, widened to the first record sharing that
+            # timestamp so simultaneous records on other channels are not dropped by TRAI >=
             trai_start = search(fun_compare=lambda t: t <= time_start, lower_bound=False)
-        if time_stop is not None:  # (first record starting after time_stop) - 1
-            trai_after = search(fun_compare=lambda t: t > time_stop, lower_bound=True)
-            trai_stop = None if trai_after is None else trai_after - 1
+            if trai_start is not None:
+                trai_start = self._first_trai_at_same_time(trai_start)
+        if time_stop is not None:  # last record starting at/before time_stop
+            trai_stop = search(fun_compare=lambda t: t <= time_stop, lower_bound=False)
         return trai_start, trai_stop
 
     def iread(
@@ -266,26 +284,28 @@ class TraDatabase(Database):
         dtype = np.int16 if raw else np.float32
         con = self.connection()
 
-        # Assume a uniform sample rate per channel; take the first record's.
-        # Indexed LIMIT 1 lookup - avoids scanning every row (e.g. DISTINCT SampleRate would).
-        row = con.execute(
-            "SELECT SampleRate FROM view_tr_data WHERE Chan == ? ORDER BY TRAI LIMIT 1", (channel,)
+        # Channel's first record (indexed point lookup): sample rate + channel start time.
+        # A `WHERE Chan == ? ORDER BY TRAI` query cannot use the TRAI index (Chan is unindexed)
+        # and would scan+sort the whole table on every call.
+        first = con.execute(
+            "SELECT Time, SampleRate FROM tr_data "
+            "WHERE TRAI == (SELECT MIN(TRAI) FROM tr_data WHERE Chan == ?)",
+            (channel,),
         ).fetchone()
-        if row is None:  # no data for this channel
+        if first is None or first[0] is None:  # no data for this channel
             empty = np.empty(0, dtype=dtype)
-            return (empty, np.empty(0, dtype=np.float32)) if time_axis else (empty, 0)
-        samplerate = row[0]
+            return (empty, np.empty(0)) if time_axis else (empty, 0)
+        samplerate = first[1]
 
-        if time_start is None or time_stop is None:  # fill open bounds from channel extent
-            extent = con.execute(
-                "SELECT MIN(Time), MAX(Time + Samples * 1.0 / SampleRate) "
-                "FROM view_tr_data WHERE Chan == ?",
+        if time_start is None:
+            time_start = first[0] / self._timebase
+        if time_stop is None:  # channel's last sample (indexed point lookup)
+            last = con.execute(
+                "SELECT Time, Samples, SampleRate FROM tr_data "
+                "WHERE TRAI == (SELECT MAX(TRAI) FROM tr_data WHERE Chan == ?)",
                 (channel,),
             ).fetchone()
-            if time_start is None:
-                time_start = extent[0]
-            if time_stop is None:
-                time_stop = extent[1]
+            time_stop = last[0] / self._timebase + last[1] / last[2]
 
         iterable = self.iread(channel=channel, time_start=time_start, time_stop=time_stop, raw=raw)
         iterator = iter(iterable)

--- a/src/vallenae/io/tradb.py
+++ b/src/vallenae/io/tradb.py
@@ -25,7 +25,9 @@ from .datatypes import TraRecord
 
 
 def _create_time_vector(samples: int, samplerate: int, pretrigger: int = 0) -> np.ndarray:
-    return np.arange(-pretrigger, samples - pretrigger, dtype=np.float32) / samplerate
+    # float64: float32 cannot resolve a 1/fs step against a large absolute offset (e.g. 10 MHz
+    # at t = 100 s, where the float32 resolution ~1e-5 is far coarser than the 1e-7 sample step).
+    return np.arange(-pretrigger, samples - pretrigger, dtype=np.float64) / samplerate
 
 
 class TraDatabase(Database):

--- a/src/vallenae/io/tradb.py
+++ b/src/vallenae/io/tradb.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import partial
-from itertools import chain
 from pathlib import Path
 from time import sleep
 from typing import Iterable, Sequence
@@ -94,45 +93,41 @@ class TraDatabase(Database):
         )
 
     def _get_total_time_range(self) -> tuple[float, float]:
-        """Return total time range [min, max] of tradb."""
-
-        def get_time(func: str):
-            result = (
-                self.connection()
-                .execute(
-                    f"SELECT Time FROM tr_data WHERE TRAI == (SELECT {func}(TRAI) from tr_data)"
-                )
-                .fetchone()
-            )
-            return 0 if result is None else result[0] / self._timebase
-
-        return get_time("MIN"), get_time("MAX")
+        """Return total time range [first sample time, end of last sample] in seconds."""
+        # view_tr_data.Time is already in seconds; the end of a record is
+        # Time + Samples / SampleRate (the `* 1.0` forces float division).
+        row = (
+            self.connection()
+            .execute("SELECT MIN(Time), MAX(Time + Samples * 1.0 / SampleRate) FROM view_tr_data")
+            .fetchone()
+        )
+        if row is None or row[0] is None:  # empty table
+            return 0.0, 0.0
+        return row[0], row[1]
 
     def _get_trai_range_from_time_range(
         self, time_start: float | None, time_stop: float | None
     ) -> tuple[int | None, int | None]:
-        """Use binary search to find indexes (TRAI) of a given time range."""
-        con = self.connection()
+        """Binary-search the TRAI range of records overlapping a time range.
+
+        Records have a duration, so the range includes the record straddling
+        time_start (start <= time_start) and the record starting at time_stop.
+        view_tr_data.Time is in seconds, so the conditions compare seconds directly.
+        """
+        search = partial(
+            sql_binary_search,
+            connection=self.connection(),
+            table="view_tr_data",
+            column_value="Time",
+            column_index="TRAI",
+        )
         trai_start = None
         trai_stop = None
-        if time_start is not None:
-            trai_start = sql_binary_search(
-                connection=con,
-                table="tr_data",
-                column_value="Time",
-                column_index="TRAI",
-                fun_compare=lambda t: t >= time_start * self._timebase,  # type: ignore
-                lower_bound=True,  # return lower index of true conditions
-            )
-        if time_stop is not None:
-            trai_stop = sql_binary_search(
-                connection=con,
-                table="tr_data",
-                column_value="Time",
-                column_index="TRAI",
-                fun_compare=lambda t: t < time_stop * self._timebase,  # type: ignore
-                lower_bound=False,  # return upper index of true conditions
-            )
+        if time_start is not None:  # last record starting at/before time_start
+            trai_start = search(fun_compare=lambda t: t <= time_start, lower_bound=False)
+        if time_stop is not None:  # (first record starting after time_stop) - 1
+            trai_after = search(fun_compare=lambda t: t > time_stop, lower_bound=True)
+            trai_stop = None if trai_after is None else trai_after - 1
         return trai_start, trai_stop
 
     def iread(
@@ -161,9 +156,9 @@ class TraDatabase(Database):
         Returns:
             Sized iterable to sequential read transient data
         """
-        # check for empty time ranges
+        # check for empty time ranges (time_max is the end of the last sample, exclusive)
         time_min, time_max = self._get_total_time_range()
-        if time_start is not None and time_start > time_max:
+        if time_start is not None and time_start >= time_max:
             return []
         if time_stop is not None and time_stop < time_min:
             return []
@@ -182,7 +177,7 @@ class TraDatabase(Database):
         """ + query_conditions(
             isin={"Chan": channel, "TRAI": trai},
             greater_equal={"TRAI": trai_start},
-            # < condition already met in binary search, use <= here for found indice range
+            # trai_start/trai_stop are inclusive bounds from the binary search
             less_equal={"TRAI": trai_stop},
             custom_filter=query_filter,
         )
@@ -232,19 +227,7 @@ class TraDatabase(Database):
             )
         return tra.data, tra.samplerate
 
-    def _get_previous_trai(self, channel: int, trai: int) -> int | None:
-        """Find previous tra record index for given channel and TRAI."""
-        result = (
-            self.connection()
-            .execute(
-                "SELECT TRAI FROM tr_data WHERE Chan == ? AND TRAI < ? ORDER BY TRAI DESC LIMIT 1",
-                (channel, trai),
-            )
-            .fetchone()
-        )
-        return result[0] if result is not None else None
-
-    def read_continuous_wave(  # pylint: disable=too-many-locals
+    def read_continuous_wave(
         self,
         channel: int,
         time_start: float | None = None,
@@ -258,6 +241,10 @@ class TraDatabase(Database):
         Read transient signal of specified channel to a single, continuous array.
 
         The signal is exactly cropped to the given time range. Time gaps are filled with 0's.
+
+        A single sample rate per channel is assumed: the sample rate of the channel's first
+        record is used. A record with a differing sample rate inside the requested range
+        raises a `RuntimeError`.
 
         Args:
             channel: Channel number to read
@@ -277,69 +264,53 @@ class TraDatabase(Database):
             - Samplerate
         """
         dtype = np.int16 if raw else np.float32
+        con = self.connection()
+
+        # Assume a uniform sample rate per channel; take the first record's.
+        # Indexed LIMIT 1 lookup - avoids scanning every row (e.g. DISTINCT SampleRate would).
+        row = con.execute(
+            "SELECT SampleRate FROM view_tr_data WHERE Chan == ? ORDER BY TRAI LIMIT 1", (channel,)
+        ).fetchone()
+        if row is None:  # no data for this channel
+            empty = np.empty(0, dtype=dtype)
+            return (empty, np.empty(0, dtype=np.float32)) if time_axis else (empty, 0)
+        samplerate = row[0]
+
+        if time_start is None or time_stop is None:  # fill open bounds from channel extent
+            extent = con.execute(
+                "SELECT MIN(Time), MAX(Time + Samples * 1.0 / SampleRate) "
+                "FROM view_tr_data WHERE Chan == ?",
+                (channel,),
+            ).fetchone()
+            if time_start is None:
+                time_start = extent[0]
+            if time_stop is None:
+                time_stop = extent[1]
+
         iterable = self.iread(channel=channel, time_start=time_start, time_stop=time_stop, raw=raw)
         iterator = iter(iterable)
         if show_progress:
-            iterator = tqdm(iterator, total=len(iterable), desc="Tra")  # ignores previous tra
+            iterator = tqdm(iterator, total=len(iterable), desc="Tra")
 
-        # prepend previous tra to iterator if available
-        trai_start, _ = self._get_trai_range_from_time_range(time_start, None)
-        if trai_start is not None:
-            previous_trai = self._get_previous_trai(channel, trai_start)
-            if previous_trai is not None:
-                iterator = chain(
-                    iter(self.iread(channel=channel, trai=previous_trai, raw=raw)),
-                    iterator,
-                )
-
-        # find beginning if not provided
-        if time_start is None:
-            time_start = self._get_total_time_range()[0]
-
-        def slice_range(tra: TraRecord):
-            """Get indices to slice given tra record data to time range."""
-
-            def limit_index(i: int):
-                return min(max(0, i), tra.samples)
-
-            n_start, n_stop = 0, tra.samples
-            if time_start is not None:
-                n_start = limit_index(round((time_start - tra.time) * tra.samplerate))
-            if time_stop is not None:
-                n_stop = limit_index(round((time_stop - tra.time) * tra.samplerate))
-            return n_start, n_stop
-
-        samplerate = 0  # will be initialized with samplerate of first record
-        tra_blocks = [np.empty(0, dtype=dtype)]
-        expected_time = time_start
+        sample_start = round(time_start * samplerate)
+        sample_stop = round(time_stop * samplerate)
+        num_samples = max(0, sample_stop - sample_start)
+        y = np.zeros(num_samples, dtype=dtype)
 
         for tra in iterator:
-            if samplerate == 0:
-                samplerate = tra.samplerate
-            if tra.samplerate != samplerate:
+            if tra.samplerate != samplerate:  # safety net for the uniform-rate assumption
                 raise RuntimeError("Different sampling rates inside requested time interval")
+            tra_start = round(tra.time * samplerate)
+            n = len(tra.data)
+            # overlapping slice of [sample_start, sample_stop) with this record's [tra_start, +n)
+            src_lo = max(0, sample_start - tra_start)
+            src_hi = min(n, sample_stop - tra_start)
+            if src_hi > src_lo:
+                dst_lo = max(0, tra_start - sample_start)
+                y[dst_lo : dst_lo + (src_hi - src_lo)] = tra.data[src_lo:src_hi]
 
-            # check for gaps in tra stream
-            time_gap = tra.time - expected_time
-            if time_gap > 1 / tra.samplerate:
-                samples_gap = round(time_gap * tra.samplerate)
-                tra_blocks.append(np.zeros(samples_gap, dtype=dtype))
-
-            sample_start, sample_stop = slice_range(tra)
-            tra_blocks.append(tra.data[sample_start:sample_stop])
-            expected_time = tra.time + sample_stop / tra.samplerate
-            if time_start is not None:
-                # the prepended record might be out of time range -> avoid exceeding zero-padding
-                expected_time = max(expected_time, time_start)
-
-        if time_stop is not None and samplerate and abs(expected_time - time_stop) > 1 / samplerate:
-            # zero padding at ending
-            samples = round((time_stop - expected_time) * samplerate)
-            tra_blocks.append(np.zeros(samples, dtype=dtype))
-
-        y = np.concatenate(tra_blocks)
         if time_axis:
-            return y, _create_time_vector(len(y), samplerate) + time_start
+            return y, _create_time_vector(num_samples, samplerate) + time_start
         return y, samplerate
 
     def listen(

--- a/src/vallenae/io/tradb.py
+++ b/src/vallenae/io/tradb.py
@@ -143,11 +143,11 @@ class TraDatabase(Database):
         if time_start is not None:
             # last record starting at/before time_start, widened to the first record sharing that
             # timestamp so simultaneous records on other channels are not dropped by TRAI >=
-            trai_start = search(fun_compare=lambda t: t <= time_start, lower_bound=False)
+            trai_start = search(fun_compare=lambda t: t <= time_start, bound="upper")
             if trai_start is not None:
                 trai_start = self._first_trai_at_same_time(trai_start)
         if time_stop is not None:  # last record starting at/before time_stop
-            trai_stop = search(fun_compare=lambda t: t <= time_stop, lower_bound=False)
+            trai_stop = search(fun_compare=lambda t: t <= time_stop, bound="upper")
         return trai_start, trai_stop
 
     def iread(

--- a/tests/test_io_sql.py
+++ b/tests/test_io_sql.py
@@ -193,36 +193,28 @@ def test_sql_binary_search():
         con.execute("INSERT INTO consts (id, value) VALUES (?, ?)", (i, 11))
         con.execute("INSERT INTO sin (id, value) VALUES (?, ?)", (i, sin(i)))
 
-    # The condition must be monotonic in `value`: lower_bound=True for False->True conditions
-    # (`>`/`>=`, match at high end, used downstream as `id >= result`), lower_bound=False for
+    # The condition must be monotonic in `value`: bound="lower" for False->True conditions
+    # (`>`/`>=`, match at high end, used downstream as `id >= result`), bound="upper" for
     # True->False conditions (`<`/`<=`, match at low end, used as `id <= result`).
 
     # squares table: strictly increasing, distinct values -> result is the exact boundary id
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 9) == 3  # id 3 -> 9
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 9) == 4  # id 4 -> 16
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 256) == 16
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 9, lower_bound=False) == 2
-    assert (
-        sql_binary_search(con, "squares", "value", "id", lambda x: x <= 9, lower_bound=False) == 3
-    )
-    assert (
-        sql_binary_search(con, "squares", "value", "id", lambda x: x < 256, lower_bound=False) == 15
-    )
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 9, "upper") == 2
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x <= 9, "upper") == 3
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 256, "upper") == 15
 
     # condition false for the whole range -> None
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 0) is None
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 99**2) is None
     # condition true for the whole range -> first / last id
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0) == 0
-    assert (
-        sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0, lower_bound=False) == 99
-    )
+    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0, "upper") == 99
 
     # consts table: all values equal -> whole range matches or none
     assert sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11) == 0
-    assert (
-        sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11, lower_bound=False) == 99
-    )
+    assert sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11, "upper") == 99
     assert sql_binary_search(con, "consts", "value", "id", lambda x: x > 11) is None
     assert sql_binary_search(con, "consts", "value", "id", lambda x: x < 11) is None
 
@@ -246,7 +238,7 @@ def test_sql_binary_search_sparse_index():
     # ids 3 and 50 straddle a gap: `value >= 50` matches from id 50, so any threshold in (3, 50]
     # selects the right rows; `value < 50` ends at id 3, so any threshold in [3, 50) does.
     upper = sql_binary_search(con, "gapped", "value", "id", lambda v: v >= 50)
-    lower = sql_binary_search(con, "gapped", "value", "id", lambda v: v < 50, lower_bound=False)
+    lower = sql_binary_search(con, "gapped", "value", "id", lambda v: v < 50, "upper")
     assert upper is not None
     assert lower is not None
     assert 3 < upper <= 50
@@ -276,13 +268,9 @@ def test_sql_binary_search_duplicate_values():
     for i, trai, value in zip([0, 1, 2, 3], [1, 2, 3, 4], [10.0, 20.0, 20.0, 40.0]):
         con.execute("INSERT INTO data (id, trai, value) VALUES (?, ?, ?)", (i, trai, value))
 
-    # value 20.0 spans trai 2 and 3: lower_bound returns the first, upper bound the last
-    assert (
-        sql_binary_search(con, "data", "value", "trai", lambda x: x <= 20.0, lower_bound=True) == 2
-    )
-    assert (
-        sql_binary_search(con, "data", "value", "trai", lambda x: x <= 20.0, lower_bound=False) == 3
-    )
+    # value 20.0 spans trai 2 and 3: "lower" returns the first, "upper" the last
+    assert sql_binary_search(con, "data", "value", "trai", lambda x: x <= 20.0, "lower") == 2
+    assert sql_binary_search(con, "data", "value", "trai", lambda x: x <= 20.0, "upper") == 3
 
     con.close()
 

--- a/tests/test_io_sql.py
+++ b/tests/test_io_sql.py
@@ -202,19 +202,27 @@ def test_sql_binary_search():
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 9) == 4  # id 4 -> 16
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 256) == 16
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 9, lower_bound=False) == 2
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x <= 9, lower_bound=False) == 3
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 256, lower_bound=False) == 15
+    assert (
+        sql_binary_search(con, "squares", "value", "id", lambda x: x <= 9, lower_bound=False) == 3
+    )
+    assert (
+        sql_binary_search(con, "squares", "value", "id", lambda x: x < 256, lower_bound=False) == 15
+    )
 
     # condition false for the whole range -> None
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x < 0) is None
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x > 99**2) is None
     # condition true for the whole range -> first / last id
     assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0) == 0
-    assert sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0, lower_bound=False) == 99
+    assert (
+        sql_binary_search(con, "squares", "value", "id", lambda x: x >= 0, lower_bound=False) == 99
+    )
 
     # consts table: all values equal -> whole range matches or none
     assert sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11) == 0
-    assert sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11, lower_bound=False) == 99
+    assert (
+        sql_binary_search(con, "consts", "value", "id", lambda x: x >= 11, lower_bound=False) == 99
+    )
     assert sql_binary_search(con, "consts", "value", "id", lambda x: x > 11) is None
     assert sql_binary_search(con, "consts", "value", "id", lambda x: x < 11) is None
 
@@ -255,6 +263,26 @@ def test_sql_binary_search_sparse_index():
     # empty table
     con.execute("CREATE TABLE empty (id INTEGER PRIMARY KEY, value REAL)")
     assert sql_binary_search(con, "empty", "value", "id", lambda v: v >= 0) is None
+
+    con.close()
+
+
+def test_sql_binary_search_duplicate_values():
+    """Regression: with duplicate values at the boundary (e.g. simultaneous hits sharing a
+    timestamp), the search must return the exact lower/upper edge of the equal-value run, so the
+    result is safe to use as an inclusive range bound."""
+    con = sqlite3.connect(":memory:")
+    con.execute("CREATE TABLE data (id INTEGER PRIMARY KEY, trai INTEGER, value REAL)")
+    for i, trai, value in zip([0, 1, 2, 3], [1, 2, 3, 4], [10.0, 20.0, 20.0, 40.0]):
+        con.execute("INSERT INTO data (id, trai, value) VALUES (?, ?, ?)", (i, trai, value))
+
+    # value 20.0 spans trai 2 and 3: lower_bound returns the first, upper bound the last
+    assert (
+        sql_binary_search(con, "data", "value", "trai", lambda x: x <= 20.0, lower_bound=True) == 2
+    )
+    assert (
+        sql_binary_search(con, "data", "value", "trai", lambda x: x <= 20.0, lower_bound=False) == 3
+    )
 
     con.close()
 

--- a/tests/test_io_tradb.py
+++ b/tests/test_io_tradb.py
@@ -231,96 +231,148 @@ def test_read_continuous_wave_empty_tradb(fresh_tradb):
     assert fs == 0
 
 
-def test_read_continuous_wave(fresh_tradb):
-    trai = 0
+FS = 100  # sample rate of the time_signal_tradb fixture
+DATA_END = 3.0  # data spans t = [0, 1) and [2, 3); open bounds resolve to [0.0, 3.0)
 
-    def write_time_axis(samplerate, samples, sets, t_start=0):
-        # create time axis
-        y = t_start + np.arange(0, samples * sets, dtype=np.float32) / samplerate
-        # write time axis blockwise
-        for data in np.reshape(y, (-1, sets)):
-            nonlocal trai
+
+@pytest.fixture(name="time_signal_tradb")
+def fixture_time_signal_tradb(fresh_tradb):
+    """Channel 1 where each sample's value equals its time, over t = [0, 1) and [2, 3) (gap)."""
+    trai = 0
+    for t_offset in (0.0, 2.0):
+        times = t_offset + np.arange(100, dtype=np.float32) / FS  # 1 s of "value == time"
+        for block in np.split(times, 10):  # 10 records of 10 samples each
             trai += 1
-            t = data[0]
             fresh_tradb.write(
                 TraRecord(
-                    time=t,
+                    time=float(block[0]),
                     channel=1,
                     param_id=1,
                     pretrigger=0,
                     threshold=0,
-                    samplerate=samplerate,
-                    samples=samples,
-                    data=data,
+                    samplerate=FS,
+                    samples=len(block),
+                    data=block,
                     trai=trai,
                 )
             )
-        return y
+    return fresh_tradb
 
-    samplerate = 100
-    samples = 10
-    sets = 10
 
-    # write data from t = [0, 1)
-    ref1 = write_time_axis(samplerate, samples, sets)
+@pytest.mark.parametrize(
+    ("time_start", "time_stop"),
+    [
+        (None, None),  # full range (with gap)
+        (0.0, 1.0),  # first data block only
+        (2.18, 2.55),  # exact range inside the second block
+        (2.13, 2.18),  # sub-record range (< 0.1 s)
+        (1.9, 2.4),  # exceeds lower bound -> leading zeros across the gap
+        (-0.1, None),  # exceeds lower bound, open stop
+        (None, 4.0),  # open start, exceeds upper bound -> trailing zeros
+        (5.0, 6.0),  # window entirely after the data -> all zeros
+        (-2.0, -1.0),  # window entirely before the data -> all zeros
+    ],
+)
+def test_read_continuous_wave_content(time_signal_tradb, time_start, time_stop):
+    y, t = time_signal_tradb.read_continuous_wave(
+        1, time_start=time_start, time_stop=time_stop, show_progress=False
+    )
+    ts = 0.0 if time_start is None else time_start
+    tp = DATA_END if time_stop is None else time_stop
+    assert len(y) == round(tp * FS) - round(ts * FS)
+    assert t[0] == pytest.approx(ts)
+    # value == time where data exists (sample indices [0, 100) and [200, 300)), else 0
+    idx = round(ts * FS) + np.arange(len(y))
+    in_data = ((idx >= 0) & (idx < 100)) | ((idx >= 200) & (idx < 300))
+    assert_allclose(y[in_data], t[in_data], atol=1e-6)  # signal equals the time axis
+    assert_allclose(y[~in_data], 0, atol=1e-6)
 
-    # get total time range
-    y, t = fresh_tradb.read_continuous_wave(1)
+
+def test_read_continuous_wave_axis_and_rate(time_signal_tradb):
+    y, t = time_signal_tradb.read_continuous_wave(
+        1, time_start=0.0, time_stop=1.0, show_progress=False
+    )
     assert y.dtype == np.float32
     assert t.dtype == np.float32
-    assert y.shape == (samples * sets,)
-    assert t.shape == y.shape
-    assert_allclose(y, ref1, atol=1e-6)
-    assert_allclose(t, ref1, atol=1e-6)
+    assert_allclose(t, np.arange(100) / FS, atol=1e-6)  # time axis values
+    _, fs = time_signal_tradb.read_continuous_wave(1, time_axis=False, show_progress=False)
+    assert fs == FS
 
-    _, fs = fresh_tradb.read_continuous_wave(1, time_axis=False)
-    assert fs == samplerate
 
-    # get empty time range
-    y, t = fresh_tradb.read_continuous_wave(1, time_start=0.1, time_stop=0.1)
+@pytest.mark.parametrize("time", [0.1, -0.1])
+def test_read_continuous_wave_empty_range(time_signal_tradb, time):
+    # time_start == time_stop -> zero-length output
+    y, t = time_signal_tradb.read_continuous_wave(
+        1, time_start=time, time_stop=time, show_progress=False
+    )
     assert len(y) == 0
     assert len(t) == 0
-    y, t = fresh_tradb.read_continuous_wave(1, time_start=-0.1, time_stop=-0.1)
-    assert len(y) == 0
-    assert len(t) == 0
 
-    # write data from t = [2, 3) -> time gap
-    ref2 = write_time_axis(samplerate, samples, sets, t_start=2)
-    ref2_total = np.concatenate([ref1, np.zeros(samples * sets), ref2])
 
-    # get total time range (with gap)
-    y, _ = fresh_tradb.read_continuous_wave(1)
-    assert y.shape == ref2_total.shape
-    assert_allclose(y, ref2_total, atol=1e-6)
+def write_tra(tradb, trai, time, n_samples, samplerate, value):
+    """Write a single transient record with constant data == value."""
+    tradb.write(
+        TraRecord(
+            time=time,
+            channel=1,
+            param_id=1,
+            pretrigger=0,
+            threshold=0,
+            samplerate=samplerate,
+            samples=n_samples,
+            data=np.full(n_samples, float(value), dtype=np.float32),
+            trai=trai,
+        )
+    )
 
-    # get exact time range
-    y, t = fresh_tradb.read_continuous_wave(1, time_start=2.18, time_stop=2.55)
-    assert len(y) == 37  # = (2.55 - 2.18) * samplerate
-    assert y[0] == pytest.approx(2.18)
-    assert y[-1] == pytest.approx(2.54)  # = 2.55 - 1/fs
-    assert t[0] == pytest.approx(2.18)
 
-    # get exact time range < 1 block (0.1 s)
-    y, t = fresh_tradb.read_continuous_wave(1, time_start=2.13, time_stop=2.18)
-    assert len(y) == 5
-    assert y[0] == pytest.approx(2.13)
-    assert y[-1] == pytest.approx(2.17)  # = 2.18 - 1/fs
-    assert t[0] == pytest.approx(2.13)
+def test_iread_time_range_record_selection(fresh_tradb):
+    # records spanning t = [k*0.1, k*0.1 + 0.1) for k = 0..4 (fs=100, 10 samples each)
+    for k in range(5):
+        write_tra(fresh_tradb, trai=k + 1, time=k * 0.1, n_samples=10, samplerate=100, value=1)
 
-    # get time range exceeding lower bound
-    y, t = fresh_tradb.read_continuous_wave(1, time_start=1.9, time_stop=2.4)
-    assert len(y) == 50  # = (2.4 - 1.9) * samplerate
-    assert y[0] == 0  # zero padded
-    assert y[-1] == pytest.approx(2.39)  # = 2.4 - 1/fs
-    assert t[0] == pytest.approx(1.9)
+    def trais(time_start, time_stop):
+        return sorted(
+            t.trai for t in fresh_tradb.iread(channel=1, time_start=time_start, time_stop=time_stop)
+        )
 
-    # get time range exceeding lower / upper bounds
-    y, t = fresh_tradb.read_continuous_wave(1, time_start=-0.1)
-    assert_allclose(y, np.concatenate([np.zeros(10), ref2_total]), atol=1e-6)
-    assert t[0] == pytest.approx(-0.1)
-    y, t = fresh_tradb.read_continuous_wave(1, time_stop=4)
-    assert_allclose(y, np.concatenate([ref2_total, np.zeros(100)]), atol=1e-6)
-    assert t[0] == pytest.approx(0.0)
+    # include the record straddling time_start (0.1 contains 0.15) and the one at time_stop (0.3)
+    assert trais(0.15, 0.30) == [2, 3, 4]
+    # a window fully inside the last record must still return it (empty-range guard regression)
+    assert trais(0.43, 0.47) == [5]
+
+
+def test_read_continuous_wave_length_invariant(fresh_tradb):
+    # burst at an awkward (non sample-aligned) time, fs=1000
+    write_tra(fresh_tradb, trai=1, time=0.015837917, n_samples=4, samplerate=1000, value=1)
+    time_start, time_stop = 0.015347917, 0.022829461
+    y, _ = fresh_tradb.read_continuous_wave(
+        1, time_start=time_start, time_stop=time_stop, show_progress=False
+    )
+    expected = round(time_stop * 1000) - round(time_start * 1000)
+    assert len(y) == expected
+
+
+def test_read_continuous_wave_samplerate_differs_from_timebase(fresh_tradb):
+    # The DB TimeBase (1e7) is NOT the record SampleRate: length and time axis must
+    # be derived from the record SampleRate (not `samplerate = self._timebase`).
+    fs = 2_000_000  # 2 MHz, != TimeBase (1e7)
+    n = 100
+    write_tra(fresh_tradb, trai=1, time=0.0, n_samples=n, samplerate=fs, value=1)
+    y, t = fresh_tradb.read_continuous_wave(
+        1, time_start=0.0, time_stop=n / fs, show_progress=False
+    )
+    assert len(y) == n  # NOT n * (1e7 / fs)
+    assert_allclose(y, np.ones(n, dtype=np.float32))
+    assert t[1] - t[0] == pytest.approx(1 / fs)
+
+
+def test_read_continuous_wave_mixed_samplerate_raises(fresh_tradb):
+    # two records on one channel with different sample rates cannot form one array
+    write_tra(fresh_tradb, trai=1, time=0.0, n_samples=10, samplerate=100, value=1)
+    write_tra(fresh_tradb, trai=2, time=0.1, n_samples=10, samplerate=200, value=2)
+    with pytest.raises(RuntimeError):
+        fresh_tradb.read_continuous_wave(1, show_progress=False)
 
 
 def test_listen(sample_tradb):

--- a/tests/test_io_tradb.py
+++ b/tests/test_io_tradb.py
@@ -309,13 +309,13 @@ def test_read_continuous_wave_empty_range(time_signal_tradb, time):
     assert len(t) == 0
 
 
-def write_tra(tradb, trai, time, n_samples, samplerate, value):
+def write_tra(tradb, trai, time, n_samples, samplerate, value, channel=1):
     """Write a single transient record with constant data == value."""
     tradb.write(
         TraRecord(
             time=time,
-            channel=1,
-            param_id=1,
+            channel=channel,
+            param_id=channel,
             pretrigger=0,
             threshold=0,
             samplerate=samplerate,
@@ -373,6 +373,28 @@ def test_read_continuous_wave_mixed_samplerate_raises(fresh_tradb):
     write_tra(fresh_tradb, trai=2, time=0.1, n_samples=10, samplerate=200, value=2)
     with pytest.raises(RuntimeError):
         fresh_tradb.read_continuous_wave(1, show_progress=False)
+
+
+def test_simultaneous_channels_at_time_boundary(fresh_tradb):
+    # Two channels with records sharing the SAME Time tick (simultaneous hits):
+    # TRAI 1->1@0.10, 2->2@0.10, 3->1@0.20, 4->2@0.20, 5->1@0.30, 6->2@0.30 (fs=100, 10 samples).
+    fresh_tradb.connection().execute(
+        "INSERT INTO tr_params (ID, SetupID, Chan, ADC_µV, TR_mV) VALUES (2, 1, 2, 1, 1)"
+    )
+    trai = 0
+    for time in (0.10, 0.20, 0.30):
+        for channel in (1, 2):
+            trai += 1
+            write_tra(fresh_tradb, trai, time, 10, 100, value=channel, channel=channel)
+
+    # time_start lands on a timestamp shared by both channels; channel 1's record at 0.20
+    # (TRAI 3) must not be dropped by the lower TRAI bound.
+    trais = sorted(t.trai for t in fresh_tradb.iread(channel=1, time_start=0.20, time_stop=0.35))
+    assert trais == [3, 5]  # channel-1 records at 0.20 and 0.30
+
+    # a window starting exactly on a shared timestamp must return channel 1's data, not 0
+    y, _ = fresh_tradb.read_continuous_wave(1, time_start=0.20, time_stop=0.30, show_progress=False)
+    assert_allclose(y, np.ones(10, dtype=np.float32))  # the channel-1 hit at 0.20
 
 
 def test_listen(sample_tradb):

--- a/tests/test_io_tradb.py
+++ b/tests/test_io_tradb.py
@@ -293,7 +293,7 @@ def test_read_continuous_wave_axis_and_rate(time_signal_tradb):
         1, time_start=0.0, time_stop=1.0, show_progress=False
     )
     assert y.dtype == np.float32
-    assert t.dtype == np.float32
+    assert t.dtype == np.float64  # time axis is float64 (precision at high sample rates)
     assert_allclose(t, np.arange(100) / FS, atol=1e-6)  # time axis values
     _, fs = time_signal_tradb.read_continuous_wave(1, time_axis=False, show_progress=False)
     assert fs == FS


### PR DESCRIPTION
`read_continuous_wave` could return the wrong number of samples and silently drop data when reading by an exact time range, especially when `time_start` falls just before or inside a hit, or when hits on different channels share a timestamp. Reads on large databases had also become slow, and the time axis lost precision at high sample rates.

### Correctness

- **Boundary records dropped**: `_get_trai_range_from_time_range` derived its TRAI bounds from record *start* times only, so it skipped the record straddling `time_start` and the record at `time_stop`. It now selects every record overlapping the range (querying `view_tr_data`, whose `Time` is in seconds, so no timebase conversion or rounding is needed). The `_get_previous_trai` prepend workaround is removed.
- **Window inside the last record returned empty**: `iread`'s empty-range guard compared `time_start` against the last record's *start* time, treating a window starting inside the final record as "past the end." `_get_total_time_range` now returns the true data extent (end of the last sample) and the guard uses it.
- **Simultaneous records on different channels were dropped**: with multiple records sharing a `Time` tick (one hit picked up on several channels), the lower bound landed on the *last* duplicate, so `TRAI >= bound` excluded the earlier ones. `sql_binary_search` now returns the exact edge of a duplicate-value run (`bound="lower"` → first, `"upper"` → last) while remaining safe against gaps in the `TRAI` column; the lower bound is then widened to the first record sharing that timestamp.
- **Wrong number of samples (±1 drift)**: `read_continuous_wave` summed independently-rounded block/gap lengths. It now preallocates `round(stop*fs) - round(start*fs)` samples and places each record by integer offset, using the record `SampleRate` (not the database `TimeBase`) and the channel's own extent for open bounds.
- **Time axis imprecise at high sample rates**: `float32` cannot resolve a 1/fs step against a large absolute offset (e.g. 10 MHz at 100 s), collapsing adjacent samples. The time axis is now `float64`.

### Performance

- Per-read full-table scans were eliminated: the total time range and the channel sample rate / extent are now indexed point lookups (`MIN`/`MAX(TRAI)` subqueries) instead of computed-aggregate or `WHERE Chan ORDER BY TRAI` scans. A windowed read on 40k records drops from ~33 ms to ~0.35 ms.

### Behavior change

- An explicit window fully outside the data now returns zeros of the requested length (consistent with the gap-fill contract) instead of an empty array.

Big thanks to @mwaltherbremen for reporting this issue and also providing the root cause analysis 👌
@mwaltherbremen, can you please review if this PR fixes the issue completely?