### PR TITLE
feat: expose show_progress in all DataFrame read methods

### DIFF
--- a/src/vallenae/io/pridb.py
+++ b/src/vallenae/io/pridb.py
@@ -114,11 +114,12 @@ class PriDatabase(Database):
             raise RuntimeError("No datetime marker in pridb") from None
         return datetime.strptime(data, "%Y-%m-%d %H:%M:%S") + timedelta(seconds=time - time_marker)
 
-    def read_hits(self, **kwargs) -> pd.DataFrame:
+    def read_hits(self, *, show_progress: bool = True, **kwargs) -> pd.DataFrame:
         """
         Read hits to Pandas DataFrame.
 
         Args:
+            show_progress: Show progress bar. Default: `True`
             **kwargs: Arguments passed to `iread_hits`
 
         Returns:
@@ -128,13 +129,15 @@ class PriDatabase(Database):
             self.iread_hits(**kwargs),
             desc="Hits",
             index_column="set_id",
+            show_progress=show_progress,
         )
 
-    def read_markers(self, **kwargs) -> pd.DataFrame:
+    def read_markers(self, *, show_progress: bool = True, **kwargs) -> pd.DataFrame:
         """
         Read marker to Pandas DataFrame.
 
         Args:
+            show_progress: Show progress bar. Default: `True`
             **kwargs: Arguments passed to `iread_markers`
 
         Returns:
@@ -148,13 +151,15 @@ class PriDatabase(Database):
             self.iread_markers(**kwargs),
             desc="Marker",
             index_column="set_id",
+            show_progress=show_progress,
         ).apply(lambda x: x.astype(dtypes.get(x.name, x.dtype)))
 
-    def read_parametric(self, **kwargs) -> pd.DataFrame:
+    def read_parametric(self, *, show_progress: bool = True, **kwargs) -> pd.DataFrame:
         """
         Read parametric data to Pandas DataFrame.
 
         Args:
+            show_progress: Show progress bar. Default: `True`
             **kwargs: Arguments passed to `iread_parametric`
 
         Returns:
@@ -164,13 +169,15 @@ class PriDatabase(Database):
             self.iread_parametric(**kwargs),
             desc="Parametric",
             index_column="set_id",
+            show_progress=show_progress,
         )
 
-    def read_status(self, **kwargs) -> pd.DataFrame:
+    def read_status(self, *, show_progress: bool = True, **kwargs) -> pd.DataFrame:
         """
         Read status data to Pandas DataFrame.
 
         Args:
+            show_progress: Show progress bar. Default: `True`
             **kwargs: Arguments passed to `iread_status`
 
         Returns:
@@ -180,14 +187,16 @@ class PriDatabase(Database):
             self.iread_status(**kwargs),
             desc="Status",
             index_column="set_id",
+            show_progress=show_progress,
         )
 
-    def read(self, **kwargs) -> pd.DataFrame:
+    def read(self, *, show_progress: bool = True, **kwargs) -> pd.DataFrame:
         """
         Read all data set types (hits, markers, parametric data, status data)
         from pridb to Pandas DataFrame.
 
         Args:
+            show_progress: Show progress bar. Default: `True`
             **kwargs: Arguments passed to `iread_hits`, `iread_markers`, `iread_parametric`
                 and `iread_status`
 
@@ -195,10 +204,10 @@ class PriDatabase(Database):
             Pandas DataFrame with all pridb data set types
         """
         # read to separate dataframes
-        df_hits = self.read_hits(**kwargs)
-        df_markers = self.read_markers(**kwargs)
-        df_parametric = self.read_parametric(**kwargs)
-        df_status = self.read_status(**kwargs)
+        df_hits = self.read_hits(show_progress=show_progress, **kwargs)
+        df_markers = self.read_markers(show_progress=show_progress, **kwargs)
+        df_parametric = self.read_parametric(show_progress=show_progress, **kwargs)
+        df_status = self.read_status(show_progress=show_progress, **kwargs)
 
         # add missing set_types
         column_set_type = 0

--- a/src/vallenae/io/tradb.py
+++ b/src/vallenae/io/tradb.py
@@ -77,11 +77,12 @@ class TraDatabase(Database):
         cur = con.execute("SELECT DISTINCT Chan FROM tr_data WHERE Chan IS NOT NULL")
         return {result[0] for result in cur.fetchall()}
 
-    def read(self, **kwargs) -> pd.DataFrame:
+    def read(self, *, show_progress: bool = True, **kwargs) -> pd.DataFrame:
         """
         Read transient data to Pandas DataFrame.
 
         Args:
+            show_progress: Show progress bar. Default: `True`
             **kwargs: Arguments passed to `iread`
 
         Returns:
@@ -91,6 +92,7 @@ class TraDatabase(Database):
             self.iread(**kwargs),
             desc="Tra",
             index_column="trai",
+            show_progress=show_progress,
         )
 
     def _get_total_time_range(self) -> tuple[float, float]:

--- a/src/vallenae/io/trfdb.py
+++ b/src/vallenae/io/trfdb.py
@@ -54,11 +54,12 @@ class TrfDatabase(Database):
         schema = schema_path.read_text("utf-8")
         create_new_database(filename, schema)
 
-    def read(self, **kwargs) -> pd.DataFrame:
+    def read(self, *, show_progress: bool = True, **kwargs) -> pd.DataFrame:
         """
         Read features to Pandas DataFrame.
 
         Args:
+            show_progress: Show progress bar. Default: `True`
             **kwargs: Arguments passed to `iread`
 
         Returns:
@@ -72,6 +73,7 @@ class TrfDatabase(Database):
             [record_to_dict(r) for r in self.iread(**kwargs)],
             desc="Trf",
             index_column="trai",
+            show_progress=show_progress,
         )
 
     def iread(


### PR DESCRIPTION
Add a keyword-only `show_progress` argument to the DataFrame read methods so the tqdm progress bar can be disabled (e.g. for scripting/logging):

- `PriDatabase.read`, `read_hits`, `read_markers`, `read_parametric`, `read_status`
- `TraDatabase.read`
- `TrfDatabase.read`

The argument is forwarded to `iter_to_dataframe` instead of leaking into the underlying `iread*` streamers via `**kwargs`.

Closes #48.