### PR TITLE
perf: speed up FLAC decode with buffer_read_into

### DIFF
--- a/src/vallenae/io/compression.py
+++ b/src/vallenae/io/compression.py
@@ -39,7 +39,14 @@ def decode_data_blob(
             return np.frombuffer(data_blob, dtype=np.int16)
         if data_format == 2:  # flac
             _check_flac_codec()
-            return sf.read(io.BytesIO(data_blob), dtype=np.int16)[0]
+            # Use the low-level buffer_read_into instead of the sf.read convenience wrapper:
+            # decode directly into a pre-sized array (~1.3x faster for many small blobs).
+            with sf.SoundFile(io.BytesIO(data_blob)) as file:
+                data_int16 = np.empty(file.frames * file.channels, dtype=np.int16)
+                file.buffer_read_into(data_int16, dtype="int16")
+                if file.channels > 1:  # match sf.read(always_2d=False): (frames, channels)
+                    data_int16 = data_int16.reshape(-1, file.channels)
+            return data_int16
         raise ValueError("Data format not supported")
 
     data_int16 = get_data_int16()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -52,3 +52,9 @@ def test_benchmark_timepicker(benchmark, random_array, function):
 @pytest.mark.parametrize("data_format", [0, 2])
 def test_benchmark_encode(benchmark, random_array, data_format):
     benchmark(compression.encode_data_blob, random_array, data_format, 0.1)
+
+
+@pytest.mark.parametrize("data_format", [0, 2])
+def test_benchmark_decode(benchmark, random_array, data_format):
+    data_blob = compression.encode_data_blob(random_array, data_format, 0.1)
+    benchmark(compression.decode_data_blob, data_blob, data_format, 0.1)


### PR DESCRIPTION
Decode FLAC blobs via the low-level `sf.SoundFile.buffer_read_into` into a pre-sized array instead of the `sf.read` convenience wrapper. This avoids per-call allocation/dispatch overhead and is ~1.3x faster for the many small blobs typical of reading waveform tables row-by-row.

Add a `test_benchmark_decode` mirroring the existing encode benchmark to keep the decode path measurable and guard against regressions.