### PR TITLE
feat: raise FileNotFoundError for missing database files

### DIFF
--- a/src/vallenae/io/_database.py
+++ b/src/vallenae/io/_database.py
@@ -46,6 +46,9 @@ class Database:
         if mode == "rwc" and not Path(filename).exists():
             self.create(filename)  # call abstract method (implemented by child class)
 
+        if not Path(filename).exists():
+            raise FileNotFoundError(f"Database file does not exist: {filename}")
+
         self._readonly = mode == "ro"
         self._connection_wrapper = ConnectionWrapper(filename, mode)
 

--- a/tests/test_io_database.py
+++ b/tests/test_io_database.py
@@ -1,5 +1,4 @@
 import pickle
-import sqlite3
 from pathlib import Path
 
 import pytest
@@ -36,7 +35,7 @@ def fixture_empty_pridb(tmp_path):
 
 def test_init():
     # try open not existing database
-    with pytest.raises(sqlite3.OperationalError):
+    with pytest.raises(FileNotFoundError):
         Database("file_does_not_exist.database", table_prefix="ae")
 
     # open existing database


### PR DESCRIPTION
Opening a non-existent database in "ro"/"rw" mode previously surfaced SQLite's cryptic "OperationalError: unable to open database file". Add an explicit existence check in Database.__init__ that raises a clear FileNotFoundError with the offending path, making path/filename typos obvious immediately.