### PR TITLE
build: migrate optional dependencies to PEP 735 dependency groups

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,16 +3,12 @@ version: 2
 formats: all
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.11"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+    python: "3.14"
+  jobs:
+    install:
+      - pip install . --group docs
 
 sphinx:
   configuration: docs/conf.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate development dependencies from optional dependencies (extras) to PEP 735 dependency groups.
+  Use `pip install -e . --group dev` (pip >= 25.1) instead of `pip install -e .[dev]`.
+
 ## [0.14.0] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Just [create an issue](https://github.com/vallen-systems/vallenae/issues/new) or
 $ git clone https://github.com/vallen-systems/vallenae.git
 $ cd vallenae
 
-# Install package and dependencies
-$ pip install -e .[dev]
+# Install package and dependencies (requires pip >= 25.1)
+$ pip install -e . --group dev
 
 # Run the test suite with tox
 $ tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "typing_extensions",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 docs = [
     "sphinx>=5",
     "sphinx-autodoc-typehints",
@@ -68,10 +68,12 @@ tests = [
 tools = [
     "mypy>=0.9",  # pyproject.toml support
     "ruff>=0.5",
-    "tox>=3.4",  # pyproject.toml support
+    "tox>=4.22",  # PEP 735 dependency_groups support
 ]
 dev = [
-    "vallenae[docs,tests,tools]", # recursive dependency since pip 21.2
+    {include-group = "docs"},
+    {include-group = "tests"},
+    {include-group = "tools"},
 ]
 
 [project.entry-points.pyinstaller40]
@@ -164,7 +166,7 @@ deps = mypy
 commands = mypy src/
 
 [testenv]
-extras = tests
+dependency_groups = tests
 commands =
     coverage run -m pytest --benchmark-disable
 
@@ -181,7 +183,7 @@ deps = pyinstaller>=4
 commands = python -m PyInstaller.utils.run_tests --include_only vallenae.
 
 [testenv:docs]
-extras = docs
+dependency_groups = docs
 changedir = docs
 commands =
     sphinx-build -b dummy . _build


### PR DESCRIPTION
Replace [project.optional-dependencies] extras (docs/tests/tools/dev) with [dependency-groups]. These are dev-only sets, so they no longer get published in the wheel/sdist metadata or installed by end users.

- pyproject.toml: add [dependency-groups]; dev uses include-group; bump tox>=4.22 and switch tox envs from `extras` to `dependency_groups`
- .readthedocs.yml: install docs group via build.jobs (pip . --group docs); bump build image to ubuntu-lts-latest / Python 3.14
- README: dev setup now uses `pip install -e . --group dev` (pip >= 25.1)

Note: `pip install vallenae[dev]` (and [docs]/[tests]/[tools]) no longer works; use `--group` instead.